### PR TITLE
Ensure correct state when short-circuitting.

### DIFF
--- a/src/RdfWriterBase.php
+++ b/src/RdfWriterBase.php
@@ -351,7 +351,10 @@ abstract class RdfWriterBase implements RdfWriter {
 	final public function about( $base, $local = null ) {
 		$this->expandSubject( $base, $local );
 
-		if ( $base === $this->currentSubject[0] && $local === $this->currentSubject[1] ) {
+		if ( $this->state === self::STATE_OBJECT
+			&& $base === $this->currentSubject[0]
+			&& $local === $this->currentSubject[1]
+		) {
 			return $this; // redundant about() call
 		}
 
@@ -392,7 +395,10 @@ abstract class RdfWriterBase implements RdfWriter {
 	final public function say( $base, $local = null ) {
 		$this->expandPredicate( $base, $local );
 
-		if ( $base === $this->currentPredicate[0] && $local === $this->currentPredicate[1] ) {
+		if ( $this->state === self::STATE_OBJECT
+			&& $base === $this->currentPredicate[0]
+			&& $local === $this->currentPredicate[1]
+		) {
 			return $this; // redundant about() call
 		}
 


### PR DESCRIPTION
When about() or say() are called again with the current subject resp. predicate,
we want to ignore the calls, to ensure nice and compact Turtle output. But
we can only do this if we are in STATE_OBJECT. Otherwise, we can end up with
illegal transitions.

This may or may not be the cause for T133924, but it should at least help us
to get better error messages.

Bug: T133924
