### PR TITLE
Fix Travis failing on PHP <5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - 7
@@ -15,9 +13,10 @@ install: travis_retry composer install
 script: composer ci
 
 notifications:
+  email: false
   irc:
     channels:
-      - "chat.freenode.net#wikimedia-dev"
+      - "chat.freenode.net#wikidata-feed"
     on_success: change
     on_failure: always
     template:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"irc": "irc://irc.freenode.net/wikimedia-dev"
 	},
 	"require": {
-		"php": ">=5.3.0"
+		"php": ">=5.5.0"
 	},
 	"require-dev": {
 		"ockcyp/covers-validator": "~0.4.0",


### PR DESCRIPTION
Requires #2.

This component already uses the `::class` feature, which requires PHP 5.5. We could downgrade to PHP 5.3, but I believe this is not worth it. Not for a brand new component like this.
